### PR TITLE
Add link to repository in a README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+Repository: <https://github.com/sschober/lapce-plugin-rewrap>


### PR DESCRIPTION
In order to make it easier to at least find the project source repository from the Lapce plugin web site. :)

(i.e. via <https://plugins.lapce.dev/plugins/sschober/lapce-plugin-rewrap>)
